### PR TITLE
upgrade github.com/klauspost/compress to v1.11.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/mostynb/zstdpool-syncpool
 
 go 1.15
 
-require github.com/klauspost/compress v1.11.6
+require github.com/klauspost/compress v1.11.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/klauspost/compress v1.11.6 h1:EgWPCW6O3n1D5n99Zq3xXBt9uCwRGvpwGOusOLNBRSQ=
-github.com/klauspost/compress v1.11.6/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.11.13 h1:eSvu8Tmq6j2psUJqJrLcWH6K3w5Dwc+qipbaA6eVEN4=
+github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=


### PR DESCRIPTION
There have been a few zstd improvements since v1.11.6:

* zstd: Big speedup on small dictionary encodes
  https://github.com/klauspost/compress/pull/345
* zstd: Add WithLowerEncoderMem
  https://github.com/klauspost/compress/pull/336
* Faster "compression" of incompressible data
  https://github.com/klauspost/compress/pull/314