### PR TITLE
upgrade github.com/klauspost/compress to v1.13.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/mostynb/zstdpool-syncpool
 
 go 1.15
 
-require github.com/klauspost/compress v1.13.0
+require github.com/klauspost/compress v1.13.3

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/klauspost/compress v1.13.0 h1:2T7tUoQrQT+fQWdaY5rjWztFGAFwbGD04iPJg90ZiOs=
-github.com/klauspost/compress v1.13.0/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
+github.com/klauspost/compress v1.13.3 h1:BtAvtV1+h0YwSVwWoYXMREPpYu9VzTJ9QDI1TEg/iQQ=
+github.com/klauspost/compress v1.13.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=


### PR DESCRIPTION
This includes the following zstd improvements since v1.13.0:

* Add configurable Decoder window size
  https://github.com/klauspost/compress/pull/394
* Add stream content size
  https://github.com/klauspost/compress/pull/401
* Simplify hashing functions
  https://github.com/klauspost/compress/pull/402
* use SpeedBestCompression for level >= 10
  https://github.com/klauspost/compress/pull/410
* Fix WriteTo error forwarding
  https://github.com/klauspost/compress/pull/411
* Improve Best compression
  https://github.com/klauspost/compress/pull/404